### PR TITLE
Fix ineffective property removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var toCamelCase = require('to-camel-case');
-var hasRemovePropertyInStyle = typeof document !== "undefined" && "removeProperty" in document.createElement("a").style;
 
 /**
  * Gets/Sets a DOM element property.
@@ -14,17 +13,10 @@ function css(element, name, value) {
   var name;
   if (arguments.length === 3) {
     name = toCamelCase((name === 'float') ? 'cssFloat' : name);
-    if (value) {
-      element.style[name] = value;
-      return value;
-    }
-    if (hasRemovePropertyInStyle) {
-      element.style.removeProperty(name);
-    } else {
-      element.style[name] = "";
-    }
+    element.style[name] = value || "";
     return value;
   }
+
   if (typeof name === "string") {
     name = toCamelCase((name === 'float') ? 'cssFloat' : name);
     return element.style[name];


### PR DESCRIPTION
Hi @jails,

I am enjoying working with dom-layer but am hitting an issue with style patching caused by this package.

The `css` function passes a camel-cased property name to `removeProperty`, but `removeProperty` appears to only work with hyphen-separated property names (e.g., `font-weight`, not `fontWeight`). I've reproduced this understanding in the latest versions of Firefox and Chrome, and the CSS Object Model working draft seems to support it as well (see items 2 and 5 [here](https://www.w3.org/TR/cssom/#dom-cssstyledeclaration-removeproperty)).

The tests probably miss this because they rely on jsdom.

I'm not sure how you'd like to address this issue, but here is a PR with my take. :) If you don't like the PR, I'll create a regular issue.

Thanks for your great work on dom-layer. You're right that the implementation is easy to read.
